### PR TITLE
feat: add individual file parameters for genotype predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # nf-gwas
 
+
+**Note:** This fork has been adapted for use with AWS HealthOmics and DNAnexus, including parameter adjustments and added support for a parameters file.
+
+---
+
 [![nf-gwas](https://github.com/genepi/nf-gwas/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/genepi/nf-gwas/actions/workflows/ci-tests.yml)
 [![nf-test](https://img.shields.io/badge/tested_with-nf--test-337ab7.svg)](https://github.com/askimed/nf-test)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ nextflow run genepi/nf-gwas -c <nextflow.config> -r v1.0.9 -profile <docker,sing
 
 Please click [here](tests) for available test config files.
 
+### New Parameter Format (Recommended)
+
+Starting from this version, you can specify individual PLINK files using separate parameters:
+
+```bash
+nextflow run genepi/nf-gwas \
+  --genotypes_prediction_bed /path/to/genotypes.bed \
+  --genotypes_prediction_bim /path/to/genotypes.bim \
+  --genotypes_prediction_fam /path/to/genotypes.fam \
+  --genotypes_association /path/to/association.vcf.gz \
+  --association_build hg19 \
+  --genotypes_association_format vcf \
+  --phenotypes_filename /path/to/phenotypes.txt \
+  --phenotypes_columns "Y1,Y2" \
+  --regenie_test additive
+```
+
+The legacy `genotypes_prediction` parameter using glob patterns is still supported but deprecated.
+
 ## Development
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # nf-gwas
 
 
-**Note:** This fork has been adapted for use with AWS HealthOmics and DNAnexus, including parameter adjustments and added support for a parameters file.
+**Note:** This fork has been specifically adapted for use with AWS HealthOmics and DNAnexus. We have modified certain input parameters to clarify file paths and included parameter definitions that are compatible with HealthOmics.
+
+* `aws-healthomics-parameters-definitions.json`: Defines parameters for creating a new workflow in HealthOmics, including descriptions for each parameter.  
+* `parameters-runready.json`: An example JSON that provides actual input values when running a workflow in HealthOmics or another platform.  
 
 ---
 

--- a/aws-healthomics-parameters-definitions.json
+++ b/aws-healthomics-parameters-definitions.json
@@ -3,8 +3,16 @@
 		"description": "s3://nci-tdrp-healthomics/data/metadata/sim_pheno_chr22_EUR_pheno.txt",
 		"optional": false
 	},
-	"genotypes_prediction": {
-		"description": "Array of PLINK genotype files (bed, bim, fam)",
+	"genotypes_prediction_bed": {
+		"description": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.bed",
+		"optional": false
+	},
+	"genotypes_prediction_bim": {
+		"description": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.bim",
+		"optional": false
+	},
+	"genotypes_prediction_fam": {
+		"description": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.fam",
 		"optional": false
 	},
 	"regenie_test": {
@@ -61,6 +69,10 @@
 	},
 	"association_build": {
 		"description": "hg38",
+		"optional": false
+	},
+	"container": {
+		"description": "222634394918.dkr.ecr.us-east-1.amazonaws.com/nf-gwas-v1.0.9",
 		"optional": false
 	}
 }

--- a/aws-healthomics-parameters-runready.json
+++ b/aws-healthomics-parameters-runready.json
@@ -1,0 +1,22 @@
+{
+  "phenotypes_filename": "s3://nci-tdrp-healthomics/data/metadata/sim_pheno_chr22_EUR_pheno.txt",
+  "genotypes_prediction_bed": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.bed",
+  "genotypes_prediction_bim": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.bim",
+  "genotypes_prediction_fam": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.fam",
+  "regenie_test": "additive",
+  "vcf_conversion_split_id": "true",
+  "rsids_filename": "s3://nci-tdrp-healthomics/data/annotations/rsids-v154-hg38.index.gz",
+  "project": "nf-gwas-sim",
+  "genotypes_association": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/bgen/all_chr.tag_chr*.bgen",
+  "phenotypes_binary_trait": "true",
+  "prune_enabled": "true",
+  "annotation_min_log10p": "2",
+  "phenotypes_columns": "sim",
+  "regenie_step1_optional": " --loocv ",
+  "phenotypes_delete_missings": "true",
+  "genotypes_association_format": "bgen",
+  "prune_maf": "0.05",
+  "association_build": "hg38",
+  "container": "222634394918.dkr.ecr.us-east-1.amazonaws.com/nf-gwas-v1.0.9"
+}
+

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -52,8 +52,19 @@ class WorkflowMain {
         Nextflow.error("Parameter genotypes_association_format is required.")
     }
 
-    if(params["genotypes_array"] == null && params["genotypes_prediction"] == null && !params.regenie_skip_predictions ) {
-        Nextflow.error("Parameter genotypes_prediction is required.")
+    // Check for new individual file parameters first, then fall back to legacy options
+    def hasNewFormat = params["genotypes_prediction_bed"] != null && 
+                       params["genotypes_prediction_bim"] != null && 
+                       params["genotypes_prediction_fam"] != null
+    def hasLegacyFormat = params["genotypes_array"] != null || params["genotypes_prediction"] != null
+    
+    if(!hasNewFormat && !hasLegacyFormat && !params.regenie_skip_predictions ) {
+        Nextflow.error("Parameters genotypes_prediction_bed, genotypes_prediction_bim, and genotypes_prediction_fam are required (or use legacy genotypes_prediction parameter).")
+    }
+    
+    // Validate that all three files are provided if using new format
+    if((params["genotypes_prediction_bed"] != null || params["genotypes_prediction_bim"] != null || params["genotypes_prediction_fam"] != null) && !hasNewFormat) {
+        Nextflow.error("When using individual file parameters, all three must be provided: genotypes_prediction_bed, genotypes_prediction_bim, and genotypes_prediction_fam.")
     }
 
     if(params["covariates_filename"] != null && (params.covariates_columns.isEmpty() && params.covariates_cat_columns.isEmpty())) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,9 @@ params {
     genotypes_association_format          = null
     genotypes_association_chunk_size      = 0
     genotypes_association_chunk_strategy  = 'RANGE'
+    genotypes_prediction_bed              = null
+    genotypes_prediction_bim              = null
+    genotypes_prediction_fam              = null
     genotypes_prediction                  = null
     genotypes_prediction_chunks           = 0
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -142,7 +142,7 @@ profiles {
     }
 
     development {
-        process.container                 = 'genepi/nf-gwas:latest'
+        process.container                 = params.container
         docker.enabled                    = true
         docker.userEmulation              = true
         resume                            = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -113,12 +113,14 @@ params {
     validate_params                       = true
      help                                 = false
 
+    container = 'quay.io/genepi/nf-gwas:v1.0.9'
+
 }
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 
-process.container = 'quay.io/genepi/nf-gwas:v1.0.9'
+process.container = params.container
 
 profiles {
     debug { process.beforeScript          = 'echo $HOSTNAME' }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -58,9 +58,27 @@
           "description": "Comma-separated list of phenotypes",
           "fa_icon": "fas fa-project-diagram"
         },
+        "genotypes_prediction_bed": {
+          "type": "string",
+          "format": "file-path",
+          "description": "Path to the BED file for genomic predictions (PLINK binary format)",
+          "fa_icon": "fas fa-project-diagram"
+        },
+        "genotypes_prediction_bim": {
+          "type": "string",
+          "format": "file-path", 
+          "description": "Path to the BIM file for genomic predictions (PLINK variant information)",
+          "fa_icon": "fas fa-project-diagram"
+        },
+        "genotypes_prediction_fam": {
+          "type": "string",
+          "format": "file-path",
+          "description": "Path to the FAM file for genomic predictions (PLINK sample information)",
+          "fa_icon": "fas fa-project-diagram"
+        },
         "genotypes_prediction": {
-          "type": "array",
-          "description": "Path to the genomic predictions (e.g. array genotypes) as a merged file in plink format).",
+          "type": "string",
+          "description": "[DEPRECATED] Use genotypes_prediction_bed/bim/fam instead. Path to the genomic predictions as a glob pattern.",
           "fa_icon": "fas fa-project-diagram"
         },
         "phenotypes_binary_trait": {

--- a/parameters-runready.json
+++ b/parameters-runready.json
@@ -4,19 +4,19 @@
   "genotypes_prediction_bim": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.bim",
   "genotypes_prediction_fam": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/data_hapmap3_only/EUR.fam",
   "regenie_test": "additive",
-  "vcf_conversion_split_id": "true",
+  "vcf_conversion_split_id": true,
   "rsids_filename": "s3://nci-tdrp-healthomics/data/annotations/rsids-v154-hg38.index.gz",
   "project": "nf-gwas-sim",
   "genotypes_association": "s3://nci-tdrp-healthomics/data/simulatedData600k_Zhang2022/bgen/all_chr.tag_chr*.bgen",
-  "phenotypes_binary_trait": "true",
-  "prune_enabled": "true",
-  "annotation_min_log10p": "2",
+  "phenotypes_binary_trait": true,
+  "prune_enabled": true,
+  "annotation_min_log10p": 2,
   "phenotypes_columns": "sim",
   "regenie_step1_optional": " --loocv ",
-  "phenotypes_delete_missings": "true",
+  "phenotypes_delete_missings": true,
   "genotypes_association_format": "bgen",
-  "prune_maf": "0.05",
+  "prune_maf": 0.05,
   "association_build": "hg38",
-  "container": "222634394918.dkr.ecr.us-east-1.amazonaws.com/nf-gwas-v1.0.9"
+  "container": "quay.io/genepi/nf-gwas:v1.0.9"
 }
 

--- a/tests/test-gwas-additive-new-format.conf
+++ b/tests/test-gwas-additive-new-format.conf
@@ -1,0 +1,29 @@
+/*
+========================================================================================
+    Nextflow config file for running tests with new individual file parameters
+========================================================================================
+*/
+
+params {
+
+  project                       = 'test-gwas-additive-new-format'
+  genotypes_prediction_bed      = "$projectDir/tests/input/pipeline/example.bed"
+  genotypes_prediction_bim      = "$projectDir/tests/input/pipeline/example.bim"
+  genotypes_prediction_fam      = "$projectDir/tests/input/pipeline/example.fam"
+  genotypes_association         = "$projectDir/tests/input/pipeline/example.vcf.gz"
+  association_build             = 'hg19'
+  genotypes_association_format  = 'vcf'
+  phenotypes_filename           = "$projectDir/tests/input/pipeline/phenotype.txt"
+  phenotypes_binary_trait       = false
+  phenotypes_columns            = 'Y1,Y2'
+  regenie_test                  = 'additive'
+  rsids_filename                = "$projectDir/tests/input/pipeline/rsids.tsv.gz"
+  annotation_min_log10p         = 2
+}
+
+process {
+    withName: '.*' {
+        cpus = 1
+        memory = 1.GB
+    }
+}

--- a/workflows/nf_gwas.nf
+++ b/workflows/nf_gwas.nf
@@ -26,10 +26,21 @@ workflow NF_GWAS {
         println ANSI_YELLOW + "WARN: Option genotypes_imputed_format is deprecated. Please use genotypes_association_format instead." + ANSI_RESET
     } 
 
-    def genotypes_prediction = params.genotypes_prediction
-    if(params.genotypes_array){
+    // Handle genotype prediction files - prefer new individual parameters
+    def genotypes_prediction = null
+    def useNewFormat = params.genotypes_prediction_bed != null && 
+                       params.genotypes_prediction_bim != null && 
+                       params.genotypes_prediction_fam != null
+    
+    if (useNewFormat) {
+        // Create a list with the individual files in the expected order [bed, bim, fam]
+        genotypes_prediction = [params.genotypes_prediction_bed, params.genotypes_prediction_bim, params.genotypes_prediction_fam]
+    } else if (params.genotypes_prediction != null) {
+        genotypes_prediction = params.genotypes_prediction
+        println ANSI_YELLOW +  "WARN: Option genotypes_prediction is deprecated. Please use genotypes_prediction_bed, genotypes_prediction_bim, and genotypes_prediction_fam instead." + ANSI_RESET
+    } else if (params.genotypes_array != null) {
         genotypes_prediction = params.genotypes_array
-        println ANSI_YELLOW +  "WARN: Option genotypes_array is deprecated. Please use genotypes_prediction instead." + ANSI_RESET
+        println ANSI_YELLOW +  "WARN: Option genotypes_array is deprecated. Please use genotypes_prediction_bed, genotypes_prediction_bim, and genotypes_prediction_fam instead." + ANSI_RESET
     }
 
     def association_build = params.association_build
@@ -62,18 +73,30 @@ workflow NF_GWAS {
     genotyped_plink_ch = Channel.empty()
     if(!skip_predictions) {
         
-        def paths = genotypes_prediction.collect { file(it) }
+        def paths
+        if (useNewFormat) {
+            // For new format, we already have the individual files in correct order
+            paths = genotypes_prediction.collect { file(it) }
+        } else {
+            // For legacy format, use the glob pattern expansion
+            paths = genotypes_prediction.collect { file(it) }
+        }
 
         // Find any of the files to extract the base name
         // We can iterate through the paths and pick the first one that has a .fam, .bim, or .bed extension
         def base_file = paths.find { it.getName().endsWith('.fam') || it.getName().endsWith('.bim') || it.getName().endsWith('.bed') }
 
         if (!base_file) {
-            error "Could not find a .fam, .bim, or .bed file in the provided genotypes_prediction array to extract the base name."
+            error "Could not find a .fam, .bim, or .bed file in the provided genotypes prediction files to extract the base name."
         }
         // Extract the ID (e.g., "EUR") from the chosen base_file
         // This regex will remove .fam, .bim, or .bed from the end of the filename
         def id = base_file.getName().replaceFirst(/\.(fam|bim|bed)$/, '')
+
+        // Ensure we have exactly 3 files for PLINK format
+        if (paths.size() != 3) {
+            error "Expected exactly 3 PLINK files (BED, BIM, FAM), but got ${paths.size()} files."
+        }
 
         genotyped_plink_ch = Channel.of(
             tuple(id,


### PR DESCRIPTION
**Description:**

This PR is based off of the `input_genotypes` branch created by @shukwong to fix an issue where the array-based `genotypes_prediction` parameter failed on DNAnexus. The array is now split using Anthropic’s Claude AI.

<br>

**Plan:**
1. Review all changes to see if make sense.
2. Upload and test the workflow on HealthOmics.
3. If successful, merge into `main` (of confluence)
4. Tag release **`v1.0.9-rti.2`**.