### PR TITLE
feat: filter chromosomes 1-22 only in prune_genotyped process

### DIFF
--- a/modules/local/prune_genotyped.nf
+++ b/modules/local/prune_genotyped.nf
@@ -13,6 +13,7 @@ process PRUNE_GENOTYPED {
     # Prune, filter and convert to plink
     plink2 \
         --bfile ${genotyped_qc_filename} \
+        --chr 1-22 \
         --double-id --maf ${params.prune_maf} \
         --indep-pairwise ${params.prune_window_kbsize} ${params.prune_step_size} ${params.prune_r2_threshold} \
         --out ${genotyped_qc_filename} \
@@ -20,6 +21,7 @@ process PRUNE_GENOTYPED {
         --memory ${task.memory.toMega()}
     plink2 \
         --bfile ${genotyped_qc_filename} \
+        --chr 1-22 \
         --extract ${genotyped_qc_filename}.prune.in \
         --double-id \
         --make-bed \


### PR DESCRIPTION
## Summary
- Add `--chr 1-22` parameter to both plink2 commands in `prune_genotyped.nf`
- Ensures only autosomal chromosomes are included in the pruning process
- Aligns with standard GWAS quality control practices

## Changes
- Modified first plink2 command to include `--chr 1-22` for linkage disequilibrium calculation
- Modified second plink2 command to include `--chr 1-22` for final pruned dataset generation

## Rationale
Including sex chromosomes (X, Y) and mitochondrial DNA in autosomal pruning can introduce bias due to:
- Different inheritance patterns
- Unique linkage structures
- Non-Mendelian inheritance for mitochondrial variants

This change ensures pruning decisions are based solely on autosomal chromosome patterns, which is the standard approach in GWAS analyses.

## Test plan
- [ ] Verify plink2 commands execute successfully with `--chr 1-22` parameter
- [ ] Confirm output contains only variants from chromosomes 1-22
- [ ] Test with existing pipeline to ensure no breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)