### PR TITLE
feat: update Regenie to version 4.1 in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN jbang export portable -O=RegenieValidateInput.jar RegenieValidateInput.java
 
 # Install regenie (not as conda package available)
 WORKDIR "/opt"
-ENV REGENIE_VERSION="v3.4"
+ENV REGENIE_VERSION="v4.1"
 RUN mkdir regenie && cd regenie && \
     wget https://github.com/rgcgithub/regenie/releases/download/${REGENIE_VERSION}/regenie_${REGENIE_VERSION}.gz_x86_64_Linux.zip && \
     unzip -q regenie_${REGENIE_VERSION}.gz_x86_64_Linux.zip && \


### PR DESCRIPTION
## Summary
- Update Regenie from v3.4 to v4.1 in Docker container
- Provide users with latest features, bug fixes, and performance improvements

## Changes
- Updated `REGENIE_VERSION` environment variable from "v3.4" to "v4.1" in Dockerfile
- Verified download URL compatibility for v4.1 release

## New Features in Regenie v4.1
- **Performance**: Timing reduction for single variant association tests in step 2 with hard-call genotype data (e.g. WES/WGS)
- **New Options**:
  - `--weights-col`: Specify custom weights for gene-based tests  
  - `--htp`: Output summary statistics in HTP format
  - `--skip-dosage-comp`: Skip dosage compensation for males in non-PAR chrX regions
- **Bug Fixes**: Various improvements and stability enhancements

## Testing
- [x] Verified v4.1 download URL exists and is accessible
- [ ] Container build test (recommended before merge)
- [ ] Workflow compatibility test with existing pipelines

## Impact
This update ensures users have access to the latest stable version of Regenie with improved performance and new functionality for GWAS analysis.

## References
- [Regenie v4.1 Release Notes](https://github.com/rgcgithub/regenie/releases/tag/v4.1)
- Resolves #6

🤖 Generated with [Claude Code](https://claude.ai/code)