### PR TITLE
feat: add BGEN indexing support and REGENIE v4.1 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,10 @@
-FROM ubuntu:22.04
-COPY environment.yml .
-
-#  Install miniconda
-RUN  apt-get update && apt-get install -y wget
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py39_23.9.0-0-Linux-x86_64.sh -O ~/miniconda.sh && \
-  /bin/bash ~/miniconda.sh -b -p /opt/conda
-ENV PATH=/opt/conda/bin:${PATH}
-
-RUN conda update -y conda && \
-    conda env update -n root -f environment.yml && \
-    conda clean --all
-
-# Install software
-RUN apt-get update && \
-    apt-get install -y gfortran \
-    python3 \
-    zlib1g-dev \
-    libgomp1 \
-    procps \
-    libx11-6
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install jbang (not as conda package available)
-WORKDIR "/opt"
-RUN wget https://github.com/jbangdev/jbang/releases/download/v0.91.0/jbang-0.91.0.zip && \
-    unzip -q jbang-*.zip && \
-    mv jbang-0.91.0 jbang  && \
-    rm jbang*.zip
-
-ENV PATH="/opt/jbang/bin:${PATH}"
-
-# Install genomic-utils
-WORKDIR "/opt"
-ENV GENOMIC_UTILS_VERSION="v0.3.7"
-RUN wget https://github.com/genepi/genomic-utils/releases/download/${GENOMIC_UTILS_VERSION}/genomic-utils.jar
-
-ENV JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork"
-
-COPY ./bin/RegenieLogParser.java ./
-RUN jbang export portable --verbose -O=RegenieLogParser.jar RegenieLogParser.java
-
-COPY ./bin/RegenieValidateInput.java ./
-RUN jbang export portable -O=RegenieValidateInput.jar RegenieValidateInput.java
+FROM quay.io/genepi/nf-gwas:v1.0.9
 
 # Install regenie (not as conda package available)
 WORKDIR "/opt"
-ENV REGENIE_VERSION="v3.4"
-RUN mkdir regenie && cd regenie && \
+ENV REGENIE_VERSION="v4.1"
+RUN rm -rf regenie && \ 
+    mkdir regenie && cd regenie && \
     wget https://github.com/rgcgithub/regenie/releases/download/${REGENIE_VERSION}/regenie_${REGENIE_VERSION}.gz_x86_64_Linux.zip && \
     unzip -q regenie_${REGENIE_VERSION}.gz_x86_64_Linux.zip && \
     rm regenie_${REGENIE_VERSION}.gz_x86_64_Linux.zip && \
@@ -55,6 +13,5 @@ RUN mkdir regenie && cd regenie && \
 
 ENV PATH="/opt/regenie/:${PATH}"
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+# Install bgenix via conda
+RUN conda install -c conda-forge bgenix

--- a/modules/local/qc_filter_genotyped.nf
+++ b/modules/local/qc_filter_genotyped.nf
@@ -4,6 +4,7 @@ process QC_FILTER_GENOTYPED {
 
     input:
     tuple val(genotyped_plink_filename), path(genotyped_plink_file)
+    path phenotypes_file_validated
 
     output:
     path "${genotyped_plink_filename}.qc.log"
@@ -13,8 +14,12 @@ process QC_FILTER_GENOTYPED {
 
 
     """
+    # Extract sample IDs from validated phenotype file
+    awk 'NR > 1 {print \$1, \$2}' ${phenotypes_file_validated} > ${genotyped_plink_filename}.keep_samples
+    
     plink2 \
         --bfile ${genotyped_plink_filename} \
+        --keep ${genotyped_plink_filename}.keep_samples \
         --maf ${params.qc_maf} \
         --mac ${params.qc_mac} \
         --geno ${params.qc_geno} \

--- a/modules/local/regenie/regenie_step2_run.nf
+++ b/modules/local/regenie/regenie_step2_run.nf
@@ -6,7 +6,7 @@ process REGENIE_STEP2_RUN {
 
     input:
 	  path step1_out
-    tuple val(filename), path(plink2_pgen_file), path(plink2_psam_file), path(plink2_pvar_file), val(range)
+    tuple val(filename), path(plink2_pgen_file), path(plink2_psam_file), path(plink2_pvar_file), val(range), path(bgi_file)
     val assoc_format
     path phenotypes_file
     path sample_file
@@ -22,6 +22,7 @@ process REGENIE_STEP2_RUN {
     script:
     def format = assoc_format == 'bgen' ? "--bgen" : '--pgen'
     def extension = assoc_format == 'bgen' ? ".bgen" : ''
+    def bgi_param = (assoc_format == 'bgen' && bgi_file && bgi_file.name != 'NO_FILE') ? "--bgi ${bgi_file}" : ''
     def bgen_sample = sample_file ? "--sample $sample_file" : ''
     def test = "--test $params.regenie_test"
     def firthApprox = params.regenie_firth_approx ? "--approx" : ""
@@ -50,6 +51,7 @@ process REGENIE_STEP2_RUN {
     regenie \
         --step 2 \
         $format ${filename}${extension} \
+        $bgi_param \
         --phenoFile ${phenotypes_file} \
         --phenoColList  ${params.phenotypes_columns} \
         --bsize ${params.regenie_bsize_step2} \

--- a/modules/local/regenie/regenie_step2_run.nf
+++ b/modules/local/regenie/regenie_step2_run.nf
@@ -6,7 +6,7 @@ process REGENIE_STEP2_RUN {
 
     input:
 	  path step1_out
-    tuple val(filename), path(plink2_pgen_file), path(plink2_psam_file), path(plink2_pvar_file), val(range), path(bgi_file)
+    tuple val(filename), path(plink2_pgen_file), path(plink2_psam_file), path(plink2_pvar_file), val(range)
     val assoc_format
     path phenotypes_file
     path sample_file
@@ -48,8 +48,8 @@ process REGENIE_STEP2_RUN {
     def step2_optional = params.regenie_step2_optional  ? "$params.regenie_step2_optional":'' 
 
     """
-    # Create .bgi index if using BGEN format and index doesn't exist
-    if [[ "$format" == "--bgen" && ! -f "${filename}.bgen.bgi" ]]; then
+    # Create .bgi index if using BGEN format
+    if [[ "$format" == "--bgen" ]]; then
         echo "Creating BGI index for ${filename}.bgen"
         bgenix -index -g ${filename}.bgen
     fi

--- a/modules/local/regenie/regenie_step2_run.nf
+++ b/modules/local/regenie/regenie_step2_run.nf
@@ -22,7 +22,7 @@ process REGENIE_STEP2_RUN {
     script:
     def format = assoc_format == 'bgen' ? "--bgen" : '--pgen'
     def extension = assoc_format == 'bgen' ? ".bgen" : ''
-    def bgi_param = (assoc_format == 'bgen' && bgi_file && bgi_file.name != 'NO_FILE') ? "--bgi ${bgi_file}" : ''
+    def bgi_param = (assoc_format == 'bgen') ? "--bgi ${filename}.bgen.bgi" : ''
     def bgen_sample = sample_file ? "--sample $sample_file" : ''
     def test = "--test $params.regenie_test"
     def firthApprox = params.regenie_firth_approx ? "--approx" : ""
@@ -48,6 +48,12 @@ process REGENIE_STEP2_RUN {
     def step2_optional = params.regenie_step2_optional  ? "$params.regenie_step2_optional":'' 
 
     """
+    # Create .bgi index if using BGEN format and index doesn't exist
+    if [[ "$format" == "--bgen" && ! -f "${filename}.bgen.bgi" ]]; then
+        echo "Creating BGI index for ${filename}.bgen"
+        bgenix -index -g ${filename}.bgen
+    fi
+
     regenie \
         --step 2 \
         $format ${filename}${extension} \

--- a/nextflow.config
+++ b/nextflow.config
@@ -113,7 +113,7 @@ params {
     validate_params                       = true
      help                                 = false
 
-    container = 'quay.io/genepi/nf-gwas:v1.0.9'
+    container = 'ghcr.io/confluence-breast-cancer-consortia/nf-gwas:regenie4.1-bgenix'
 
 }
 

--- a/workflows/gene_based_tests.nf
+++ b/workflows/gene_based_tests.nf
@@ -66,7 +66,7 @@ workflow GENE_BASED_TESTS {
    
     if (!skip_predictions) {
 
-        QUALITY_CONTROL(genotyped_plink_ch)
+        QUALITY_CONTROL(genotyped_plink_ch, phenotypes_file_validated)
         genotyped_final_ch = QUALITY_CONTROL.out.genotyped_filtered_files_ch
         genotyped_filtered_snplist_ch = QUALITY_CONTROL.out.genotyped_filtered_snplist_ch
         genotyped_filtered_id_ch = QUALITY_CONTROL.out.genotyped_filtered_id_ch

--- a/workflows/quality_control.nf
+++ b/workflows/quality_control.nf
@@ -3,12 +3,14 @@ include { QC_FILTER_GENOTYPED } from '../modules/local/qc_filter_genotyped'
 workflow QUALITY_CONTROL {
 
     take:
-    genotyped_plink_ch    
+    genotyped_plink_ch
+    phenotypes_file_validated    
     
     main:
 
     QC_FILTER_GENOTYPED (
-        genotyped_plink_ch
+        genotyped_plink_ch,
+        phenotypes_file_validated
     )
 
     emit: 

--- a/workflows/regenie/regenie_step2.nf
+++ b/workflows/regenie/regenie_step2.nf
@@ -19,9 +19,33 @@ workflow REGENIE_STEP2 {
         sample_file = file(params.regenie_sample_file, checkIfExists: true)
     }
 
+    // Add BGI file handling for BGEN format
+    imputed_plink2_ch
+        .map { filename, file1, file2, file3, range ->
+            def bgi_file = null
+            
+            if (genotypes_association_format == 'bgen') {
+                // Check if file2 is already a BGI file (from chunking)
+                if (file2 && file2.toString().endsWith('.bgi')) {
+                    bgi_file = file2
+                } 
+                // Check if file2 is an empty list (no chunking case)
+                else if (!file2 || file2.toString() == '[]') {
+                    // Construct BGI from BGEN filename
+                    def potential_bgi = file("${file1}.bgi")
+                    bgi_file = potential_bgi.exists() ? potential_bgi : file('NO_FILE')
+                }
+            } else {
+                bgi_file = file('NO_FILE')
+            }
+            
+            tuple(filename, file1, file2, file3, range, bgi_file)
+        }
+        .set { regenie_input_with_bgi }
+
     REGENIE_STEP2_RUN (
         regenie_step1_out_ch.collect(),
-        imputed_plink2_ch,
+        regenie_input_with_bgi,
         genotypes_association_format,
         phenotypes_file_validated,
         sample_file,

--- a/workflows/regenie/regenie_step2.nf
+++ b/workflows/regenie/regenie_step2.nf
@@ -19,33 +19,9 @@ workflow REGENIE_STEP2 {
         sample_file = file(params.regenie_sample_file, checkIfExists: true)
     }
 
-    // Add BGI file handling for BGEN format
-    imputed_plink2_ch
-        .map { filename, file1, file2, file3, range ->
-            def bgi_file = null
-            
-            if (genotypes_association_format == 'bgen') {
-                // Check if file2 is already a BGI file (from chunking)
-                if (file2 && file2.toString().endsWith('.bgi')) {
-                    bgi_file = file2
-                } 
-                // Check if file2 is an empty list (no chunking case)
-                else if (!file2 || file2.toString() == '[]') {
-                    // Construct BGI from BGEN filename
-                    def potential_bgi = file("${file1}.bgi")
-                    bgi_file = potential_bgi.exists() ? potential_bgi : file('NO_FILE')
-                }
-            } else {
-                bgi_file = file('NO_FILE')
-            }
-            
-            tuple(filename, file1, file2, file3, range, bgi_file)
-        }
-        .set { regenie_input_with_bgi }
-
     REGENIE_STEP2_RUN (
         regenie_step1_out_ch.collect(),
-        regenie_input_with_bgi,
+        imputed_plink2_ch,
         genotypes_association_format,
         phenotypes_file_validated,
         sample_file,

--- a/workflows/single_variant_tests.nf
+++ b/workflows/single_variant_tests.nf
@@ -58,7 +58,7 @@ workflow SINGLE_VARIANT_TESTS {
    
     if (!skip_predictions) {
 
-        QUALITY_CONTROL(genotyped_plink_ch)
+        QUALITY_CONTROL(genotyped_plink_ch, phenotypes_file_validated)
         genotyped_final_ch = QUALITY_CONTROL.out.genotyped_filtered_files_ch
         genotyped_filtered_snplist_ch = QUALITY_CONTROL.out.genotyped_filtered_snplist_ch
         genotyped_filtered_id_ch = QUALITY_CONTROL.out.genotyped_filtered_id_ch


### PR DESCRIPTION
## Summary
- Add automatic BGEN indexing to REGENIE step 2
- Upgrade REGENIE to version 4.1 with bgenix support
- Add explicit BGI file support for REGENIE step 2
- Subset genotyped files to phenotype samples before QC filtering
- Simplify BGEN indexing implementation
- Update container to confluence-breast-cancer-consortia registry

## Test plan
- [ ] Verify REGENIE step 2 works with BGEN files and automatic indexing
- [ ] Test BGI file handling in REGENIE workflows
- [ ] Validate genotype subsetting functionality
- [ ] Confirm compatibility with REGENIE v4.1
- [ ] Test new container image functionality

🤖 Generated with [Claude Code](https://claude.ai/code)